### PR TITLE
Added breakword css so notes don't break with big strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/wp-dashboard-notes.php
+++ b/wp-dashboard-notes.php
@@ -267,7 +267,10 @@ class WP_Dashboard_Notes {
 
 		// Inline styling required for note depending colors.
 		?><style>
-			#note_<?php echo $note->ID; ?> { background-color: <?php echo $note_meta['color']; ?>; }
+			#note_<?php echo $note->ID; ?> {
+                background-color: <?php echo $note_meta['color']; ?>;
+                word-wrap: break-word;
+            }
 			#note_<?php echo $note->ID; ?> .hndle { border: none; }
 		</style><?php
 


### PR DESCRIPTION
Hi, I'm using this plugin, and I noticed while using urls that big strings break the layout. I placed a small css fix for that and prepared this PR.

I noticed that there is a difference of tag/spaces with my IDE, but because at this stage the plugin doesn't have a php.cs file where we could base on, there will be no problem - but let me know if you think is the best to manually place those spaces/tabs now.

Thanks for this amazing plugin!